### PR TITLE
Remove ssi crate and use fallback DID builder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,34 +4,23 @@ version = "0.2.0"
 edition = "2021"
 
 [dependencies]
-# crypto & encoding
 p256 = { version = "0.13", features = ["pkcs8"] }
 rand = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 base64 = "0.22"
 
-# password hashing + AEAD for keystore
 argon2 = "0.5"
-aes-gcm = { version = "0.10", features = ["aes256"] }  # AES-256-GCM
+aes-gcm = { version = "0.10", features = ["aes256"] }
 hkdf = "0.12"
 sha2 = "0.10"
 
-# CLI & GUI
 clap = { version = "4", features = ["derive"] }
-eframe = "0.29"   # egui native app
+eframe = "0.29"
 egui = "0.29"
 
-# time / fs
 time = { version = "0.3", features = ["macros"] }
 dirs = "5"
-
-# zip for backup bundles
 zip = "0.6"
-
-# OPTIONAL: proper did:key
-ssi = { version = "0.7", default-features = false, features = ["did-key","secp256r1","jwk"] }
-
-# small errors
 anyhow = "1"
 


### PR DESCRIPTION
## Summary
- drop the `ssi` dependency and clean up `Cargo.toml`
- simplify DID generation to always use the fallback helper

## Testing
- `cargo build` *(fails: failed to download from `https://index.crates.io/config.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68b181e626a8832bad31e056be7230d0