### PR TITLE
Use aes feature for aes-gcm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ serde_json = "1"
 base64 = "0.22"
 
 argon2 = "0.5"
-aes-gcm = { version = "0.10", features = ["aes256"] }
+aes-gcm = { version = "0.10", features = ["aes"] }
 hkdf = "0.12"
 sha2 = "0.10"
 


### PR DESCRIPTION
## Summary
- use `aes` feature for `aes-gcm` crate and keep 256-bit type in code

## Testing
- `cargo test` *(fails: download of config.json failed: [56] Failure when receiving data from the peer (CONNECT tunnel failed, response 403))*

------
https://chatgpt.com/codex/tasks/task_e_68b18416ba18832bb3a9d02e1d728f21