### PR TITLE
Refactor CLI and GUI output handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ clap = { version = "4", features = ["derive"] }
 eframe = "0.29"
 egui = "0.29"
 
-time = { version = "0.3", features = ["macros"] }
+time = { version = "0.3", features = ["macros", "formatting"] }
 dirs = "5"
 zip = "0.6"
 anyhow = "1"


### PR DESCRIPTION
## Summary
- enable RFC 3339 formatting support in `time`
- remove `PathBuf` defaults from CLI, resolving defaults in code and GUI
- tighten error handling and use `verifying_key` for public key extraction

## Testing
- `cargo clean`
- `cargo update` *(fails: failed to download from `https://index.crates.io/config.json`)*
- `cargo check` *(fails: failed to download from `https://index.crates.io/config.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68b18eca2328832bbe3b10f1601be37d