### PR TITLE
Use spec-compliant did:key generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ anyhow = "1"
 reqwest = { version = "0.12", features = ["json", "blocking", "rustls-tls"] }
 jsonschema = "0.17"
 url = "2.5"
+ssi = { version = "0.7", default-features = false, features = ["jwk", "secp256r1"] }
 
 [build-dependencies]
 winres = { version = "0.1", optional = true }


### PR DESCRIPTION
## Summary
- generate spec-compliant `did:key` using the `ssi` crate
- include JWS 2020 context in generated DID Document
- add `ssi` dependency

## Testing
- `cargo test` *(fails: failed to download from `https://index.crates.io/config.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e9519f88832bb661c256f8a3ffa4