### PR TITLE
Generate spec-compliant did:key using multicodec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ anyhow = "1"
 reqwest = { version = "0.12", features = ["json", "blocking", "rustls-tls"] }
 jsonschema = "0.17"
 url = "2.5"
-ssi = { version = "0.7", default-features = false, features = ["jwk", "secp256r1"] }
+bs58 = "0.5"
 
 [build-dependencies]
 winres = { version = "0.1", optional = true }


### PR DESCRIPTION
## Summary
- Generate did:key identifiers using multicodec + multibase for P-256 keys
- Add bs58 dependency and helper functions for varint and did:key encoding
- Remove ssi fallback and keep DID Document contexts

## Testing
- `cargo test` *(fails: failed to download from `https://index.crates.io/config.json`)*
- `cargo test --offline` *(fails: no matching package named `bs58` found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1fac75eb4832ba65786c28f1e35ec